### PR TITLE
Update image_encoder.py

### DIFF
--- a/image_encoder.py
+++ b/image_encoder.py
@@ -1,11 +1,11 @@
-from PIL import Image
+from PIL import Image, PngImagePlugin
 import math
 
 BASE_MAP = {'A': '00', 'C': '01', 'G': '10', 'T': '11'}
 BIT_TO_BASE = {v: k for k, v in BASE_MAP.items()}
 
 def base_to_bits(base: str) -> str:
-    return BASE_MAP.get(base.upper(), '00')  # defaults 'A'→'00'
+    return BASE_MAP.get(base.upper(), '00')  # Defaults to 'A'->'00' if unknown
 
 def kmer_to_color(kmer: str) -> tuple[int, int, int]:
     # K=12 → 24 bits
@@ -15,7 +15,7 @@ def kmer_to_color(kmer: str) -> tuple[int, int, int]:
     b = int(bits[16:24], 2)
     return (r, g, b)
 
-def encode_sequence_to_image(dna: str, K: int = 12, scale: int = 100000) -> Image.Image:
+def encode_sequence_to_image(dna: str, K: int = 12, scale: int = 1) -> Image.Image:
     remainder = len(dna) % K
     if remainder != 0:
         dna += 'A' * (K - remainder)  # pad
@@ -39,18 +39,25 @@ def encode_sequence_to_image(dna: str, K: int = 12, scale: int = 100000) -> Imag
     img.putdata(pixels)
 
     if scale > 1:
+        # Nearest neighbor scaling results in each pixel becoming a block of scale x scale
         img = img.resize((width * scale, height * scale), Image.NEAREST)
 
-    return img
+    # Add scale factor metadata
+    meta = PngImagePlugin.PngInfo()
+    meta.add_text("scale_factor", str(scale))
+    # You can add more metadata here if needed
+
+    # Save into a BytesIO in memory, then reopen to return a properly formatted PNG in memory
+    # or simply return img and let calling code save with pnginfo
+    # For direct return, just store the meta in memory:
+    # We'll rely on the caller to save it with pnginfo if needed.
+    return img, meta
 
 def decode_pixel_to_kmer(r, g, b, K=12) -> str:
-    # Reverse operation of kmer_to_color
-    # Convert R,G,B to binary and then decode to bases
     r_bits = f"{r:08b}"
     g_bits = f"{g:08b}"
     b_bits = f"{b:08b}"
     full_bits = r_bits + g_bits + b_bits  # 24 bits total for K=12
-    
     kmer = ''
     for i in range(K):
         base_bits = full_bits[i*2:(i*2)+2]
@@ -58,10 +65,31 @@ def decode_pixel_to_kmer(r, g, b, K=12) -> str:
     return kmer
 
 def decode_image_to_sequence(img: Image.Image, K: int = 12) -> str:
-    pixels = list(img.getdata())
+    # Extract scale_factor from metadata
+    scale_factor_str = img.text.get("scale_factor", "1")
+    scale_factor = int(scale_factor_str)
+
+    width, height = img.size
+    if scale_factor > 1:
+        # The image is scaled up. Each original pixel is a scale_factor x scale_factor block.
+        original_width = width // scale_factor
+        original_height = height // scale_factor
+
+        pixel_data = list(img.getdata())
+        original_pixels = []
+        for y in range(original_height):
+            for x in range(original_width):
+                # Take the top-left pixel of each block to reconstruct original pixels
+                px = pixel_data[(y * scale_factor) * width + (x * scale_factor)]
+                original_pixels.append(px)
+    else:
+        # scale_factor = 1, no scaling needed
+        original_pixels = list(img.getdata())
+
     decoded_seq = ""
-    for p in pixels:
+    for p in original_pixels:
         r, g, b = p
         kmer = decode_pixel_to_kmer(r, g, b, K)
         decoded_seq += kmer
+
     return decoded_seq

--- a/main.py
+++ b/main.py
@@ -2,9 +2,10 @@ import streamlit as st
 from utils import parse_fasta
 from image_encoder import encode_sequence_to_image, decode_image_to_sequence
 from io import BytesIO
+from PIL import Image
 
 st.set_page_config(layout="wide")
-st.sidebar.title("DNA to Color Encoder/Decoder")
+st.sidebar.title("DNA to Color Encode/Decode (PNG)")
 
 mode = st.sidebar.selectbox("Mode", ["Generate", "Convert from PNG"])
 
@@ -12,6 +13,12 @@ if mode == "Generate":
     st.sidebar.write("**Provide DNA sequence (FASTA):**")
     fasta_sequence = st.sidebar.text_area("Paste FASTA sequence:")
     fasta_file = st.sidebar.file_uploader("Or upload FASTA/TXT:", type=["fasta", "fa", "txt"])
+
+    # Slider for scaling factor
+    scale = st.sidebar.slider("Scaling factor (large values = bigger image but not directly decodable)", 
+                              min_value=1, max_value=1000000, step=250, value=1)
+    st.sidebar.caption("Note: If you set scale > 1, decoding directly requires correction.\nKeep scale=1 if you plan to decode later.")
+
     submit = st.sidebar.button("Submit")
 
     if submit:
@@ -30,16 +37,17 @@ if mode == "Generate":
             st.error("Sequence too short. Need at least 12 bases.")
             st.stop()
 
-        img = encode_sequence_to_image(dna, K=12, scale=10)
+        img, meta = encode_sequence_to_image(dna, K=12, scale=scale)
 
-        # Display image
-        st.image(img, caption="Encoded DNA Image (PNG)")
-
-        # Provide download button
+        # Save image with metadata into memory
         img_buffer = BytesIO()
-        img.save(img_buffer, format="PNG")
+        img.save(img_buffer, format="PNG", pnginfo=meta)
         img_buffer.seek(0)
 
+        # Display image
+        st.image(img, caption=f"Encoded DNA Image (PNG) [Scale: {scale}]")
+
+        # Provide download button
         st.download_button(
             label="Download PNG",
             data=img_buffer,
@@ -58,14 +66,13 @@ elif mode == "Convert from PNG":
             st.stop()
 
         # Load image from memory
-        from PIL import Image
         img = Image.open(png_file)
         decoded_seq = decode_image_to_sequence(img, K=12)
-        
+
         st.write("**Decoded Sequence:**")
         st.text(decoded_seq)
 
-        # Optionally provide a way to download decoded sequence as FASTA
+        # Provide a download button for the decoded FASTA
         fasta_content = f">decoded_sequence\n{decoded_seq}\n"
         st.download_button(
             label="Download Decoded FASTA",


### PR DESCRIPTION
A slider for scaling factor in the "Generate" mode (from 1 to 1,000,000 in increments of 250). A note warning the user that scaling > 1 requires extra steps to decode properly. PNG metadata to store the scale factor used during image creation. Adjusted decoding logic to use the scale factor from the metadata: If scale_factor > 1, the decoding function "downsamples" the image to recover the original pixel grid.